### PR TITLE
Introduce prop `output`

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ Default: `{}`
 
 The key values you wish to add or modify to the existing `manifest.json` file. For a full list of key values to use [see here.](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json)
 
+### output
+
+_Optional_
+
+Type: `string`
+
+Default: `manifest.json`
+
+Unique output directory to write the manifest file to, useful for building your app outside of the root rollup folder.
+
 ## Contributors
 
 Don't be scared to raise an issue or a pull request! Any contributions, no matter how big or small will land your picture here and be greatly appreciated ❤️

--- a/package.json
+++ b/package.json
@@ -3,8 +3,6 @@
   "version": "1.4.2",
   "description": "Rollup plugin to generate a manifest.json file used to tell the browser about your web app.",
   "main": "lib/rollup-plugin-manifest-json.cjs.js",
-  "module": "lib/rollup-plugin-manifest-json.es.js",
-  "jsnext:main": "lib/rollup-plugin-manifest-json.es.js",
   "scripts": {
     "test": "mocha",
     "pretest": "npm run build",
@@ -40,7 +38,6 @@
     "typescript": "^4.0.2"
   },
   "files": [
-    "lib/rollup-plugin-manifest-json.es.js",
     "lib/rollup-plugin-manifest-json.cjs.js",
     "lib/index.d.ts"
   ],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,10 +4,10 @@ import { terser } from "rollup-plugin-terser";
 
 export default{
     input: "src/index.ts",
-    output: [
-        { file: "lib/rollup-plugin-manifest-json.cjs.js", format: "cjs" },
-        { file: "lib/rollup-plugin-manifest-json.es.js", format: "esm" }
-    ],
+    output: {
+      file: "lib/rollup-plugin-manifest-json.cjs.js",
+      format: "cjs"
+    },
     plugins: [
         typescript(),
         babel({

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -42,7 +42,12 @@ export interface ManifestOptions {
 }
 
 export interface PluginOptions {
-    input: string,
-    minify?: boolean,
-    manifest?: ManifestOptions
+  /** File path to your `manifest.json` file. */
+  input: string,
+  /** Whether or not to mangle the outputted manifest. */
+  minify?: boolean,
+  /** Directory to store the manifest file in. */
+  output?: string,
+  /** Manifest options */
+  manifest?: ManifestOptions
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from "fs";
-import { resolve } from "path";
+import { resolve, normalize } from "path";
 
 import { Plugin } from "rollup";
 import { PluginOptions, ManifestOptions } from "./index.d";
@@ -8,19 +8,21 @@ export default function manifestJson(opts: PluginOptions): Plugin  {
     return {
         name: "manifest-json",
         buildStart() {
-            if (opts.input == undefined) {
-                throw new Error(`...Looks like you didn't specify an input file chief`);
-            }
+          const { input, manifest, minify, output } = opts;
 
-            let manifestData: ManifestOptions = JSON.parse(readFileSync(resolve(opts.input), `utf-8`));
+          if (!input) {
+              throw new Error('Is the `input` option set to something?');
+          }
 
-            Object.assign(manifestData, opts.manifest);
+          const manifestData: ManifestOptions = JSON.parse(readFileSync(resolve(input), `utf-8`));
 
-            this.emitFile({
-                type: "asset",
-                source: opts.minify ? JSON.stringify(manifestData) : JSON.stringify(manifestData, null, 2),
-                fileName: "manifest.json",
-            })
+          Object.assign(manifestData, manifest);
+
+          this.emitFile({
+              type: "asset",
+              source: minify ? JSON.stringify(manifestData) : JSON.stringify(manifestData, null, 2),
+              fileName: output ? normalize(`${output}/manifest.json`) : 'manifest.json',
+          });
         }
     }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "target": "esnext",
+        "target": "es2017",
         "module": "esnext",
         "strict": true,
         "moduleResolution": "node",


### PR DESCRIPTION
fixes #5 

@MrFoxPro This should resolve the problem you outlined, with the new prop `output` you can specify a different output directory, relative to your rollup output.